### PR TITLE
Fix for the Text lines list not being saved to the config file.

### DIFF
--- a/TextCommand.cs
+++ b/TextCommand.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace ZaupTextCommands
+{
+    public sealed class TextCommand
+    {
+        public string Name;
+        public string Help;
+        [XmlArrayItem("Line")]
+        public List<String> Text;
+    }
+}

--- a/ZaupTextCommandConfiguration.cs
+++ b/ZaupTextCommandConfiguration.cs
@@ -6,24 +6,23 @@ namespace ZaupTextCommands
 {
     public class ZaupTextCommandConfiguration : IRocketPluginConfiguration
     {
-        public List<ZaupTextCommand> commands;
+        public List<TextCommand> commands;
 
         public void LoadDefaults()
         {
-            commands = new List<ZaupTextCommand>()
+            commands = new List<TextCommand>()
             {
-                new ZaupTextCommand
-                (
-                    "rules", 
-                    "Displays the server rules", 
-                    new List<string>() {
+                new TextCommand{
+                    Name = "rules", 
+                    Help = "Displays the server rules", 
+                    Text = new List<string>() {
                         "No harrasment",
                         "No cursing", 
                         "No griefing",
                         "Any of the above will get you banned.",
                         "The above is just a sample of what you could use this for."
                     }
-                )
+                }
             };
         }
     }

--- a/ZaupTextCommands.cs
+++ b/ZaupTextCommands.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 
 using Rocket.API;
 using Rocket.Core;
@@ -22,9 +21,9 @@ namespace ZaupTextCommands
         {
             if (this.Configuration.Instance.commands.Count > 0 && this.Configuration != null && this.Configuration.Instance.commands != null)
             {
-                foreach (ZaupTextCommand command in this.Configuration.Instance.commands)
+                foreach (TextCommand command in this.Configuration.Instance.commands)
                 {
-                    Commander.register(command);
+                    Commander.register(new ZaupTextCommand(command.Name, command.Help, command.Text));
                 }
             }
         }
@@ -32,7 +31,10 @@ namespace ZaupTextCommands
         {
             if (this.Configuration.Instance.commands.Count > 0 && this.Configuration != null && this.Configuration.Instance.commands != null)
             {
-                foreach (ZaupTextCommand command in this.Configuration.Instance.commands)
+                foreach (Command command in (
+                    from c in Commander.Commands
+                    where c is ZaupTextCommand
+                    select c).ToList<Command>())
                 {
                     Commander.deregister(command);
                 }


### PR DESCRIPTION
This pull request fixes the bug with the text lines not being saved to the config file. The pull request also partially rolls back the commit https://github.com/Zamirathe/ZaupTextCommand/commit/a398107be9e7c4cf2b0f5aad7ff8dea7b3bd69c8, in that is reimpliments the TextCommand class, and it changes the ZaupTextCommand XML element in command back to TextCommand.

I've had a chance to test this and it loads and unloads/reloads properly.
